### PR TITLE
Depends_on syntax changed.

### DIFF
--- a/elasticsearch@5.6.rb
+++ b/elasticsearch@5.6.rb
@@ -6,7 +6,7 @@ class ElasticsearchAT56 < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.8"
+  depends_on "openjdk"
 
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"


### PR DESCRIPTION
Not sure it's the right way, but it solved the issue for me in my fork with the message

`Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.`